### PR TITLE
fix: replace timestamp() rebuild with fileexists() artifact check

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -78,7 +78,7 @@ resource "random_string" "this" {
   keepers = {
     artifact_sha      = data.archive_file.this[0].output_sha
     docker_build_args = jsonencode(var.docker_build_args)
-    force_rebuild_id  = coalesce(var.force_rebuild_id, timestamp())
+    force_rebuild_id  = var.force_rebuild_id
   }
 }
 
@@ -86,8 +86,9 @@ resource "null_resource" "this" {
   count = module.artifact_label.enabled ? 1 : 0
 
   triggers = {
-    artifact_image = docker_image.this[0].image_id
-    artifact_path  = local.artifact_dst_path
+    artifact_image  = docker_image.this[0].image_id
+    artifact_path   = local.artifact_dst_path
+    artifact_exists = local.artifact_dst_path != null ? fileexists(local.artifact_dst_path) : false
   }
 
   provisioner "local-exec" {


### PR DESCRIPTION
## Summary

- Remove `coalesce(var.force_rebuild_id, timestamp())` from `random_string` keepers which forced a full Docker rebuild on every `terraform apply`
- Add `fileexists()` trigger on `null_resource` to detect when the extracted artifact file is missing on disk and re-extract it

## Problem

In v1.4.0, the `force_rebuild_id` keeper was changed to `coalesce(var.force_rebuild_id, timestamp())`. When `force_rebuild_id` is empty (the default), `timestamp()` changes every run, regenerating the `random_string` and cascading through `docker_image` and `null_resource` — forcing a full rebuild on every apply even when nothing changed. This also causes a race condition in downstream consumers using `filebase64sha256()` on the artifact path, since the file at the new path doesn't exist yet during plan evaluation.

## Fix

**`random_string` keepers (line 81):** Revert to `var.force_rebuild_id` directly. Content-based rebuild detection via `artifact_sha` and `docker_build_args` keepers is preserved.

**`null_resource` triggers (line 91):** Add `artifact_exists = fileexists(local.artifact_dst_path)` so that when the artifact file is missing on disk (docker prune, different machine, CI), the provisioner re-runs to extract it. This addresses the original problem that motivated the `timestamp()` hack without the side effects.

`fileexists()` evaluates at plan time against what's on disk, and the path is known (stable) in exactly the case where this check matters — when nothing else has changed but the local file is gone. When the `random_string` is being regenerated (source or args changed), the path becomes `(known after apply)` and the `null_resource` is already being replaced via the other triggers.

Closes #7